### PR TITLE
Make Google domain matching slightly more precise

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
 
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["*://*/"],
       "js": ["override-google-rwt.js"]
     }
   ]

--- a/override-google-rwt.js
+++ b/override-google-rwt.js
@@ -17,9 +17,11 @@
  * along with Avoid Google Search redirects.If not, see <http://www.gnu.org/licenses/>.
  */
 
-currentURL = new URL(window.location.href)
+const currentURL = new URL(window.location.href);
+// can’t use `"matches": ["*://*.google.*/"]` in `manifest.json` because
+// `*` is only supported at the beginning of the hostname
+const currentURLIsAGoogleDomain = currentURL.hostname.match(/\.google(\.[^\.]+|\.co\.uk)$/);
 
-if (window.wrappedJSObject.rwt
-    && currentURL.hostname.match(/\.google\.[^\.]+$/)) {
+if (currentURLIsAGoogleDomain && window.wrappedJSObject.rwt) {
     window.wrappedJSObject.rwt = exportFunction(function() { }, window);
 }


### PR DESCRIPTION
This goes some of the way towards addressing [issue #1](https://github.com/Trim/avoid-google-search-redirects/issues/1). It addresses the reviewer’s first bullet point about using globs, but not in the ideal manner.

- `"*://*/"` limits matches to the HTTP and HTTPS protocols, improving security and performance on other protocols.

- Extracting the hostname check to a variable and doing the domain check before the `window.wrappedJSObject.rwt` check makes the code easier to read and easier to confirm which sites the code runs on.